### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
     "vscode": {
       "extensions": [
         "ms-toolsai.jupyter",
-        "ms-python.python"
+        "ms-python.python",
+        "github.copilot"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "postCreateCommand": "python3 -m pip install -r Application/requirements.txt",
+  "customizations": {
+    "codespaces": {
+      "openFiles": ["README.md"]
+    },
+    "vscode": {
+      "extensions": [
+        "ms-toolsai.jupyter",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/Track_2_ToDo_App/Sprint-00 - Environment Setup/02a - Use GitHub CodeSpaces.md
+++ b/Track_2_ToDo_App/Sprint-00 - Environment Setup/02a - Use GitHub CodeSpaces.md
@@ -70,7 +70,8 @@ In our project, you'll find a file named `devcontainer.json` which is located in
     "vscode": {
       "extensions": [
         "ms-toolsai.jupyter",
-        "ms-python.python"
+        "ms-python.python",
+        "github.copilot"
       ]
     }
   }
@@ -105,11 +106,14 @@ The `devcontainer.json` file also allows us to customize our Codespaces environm
 
 - `"codespaces"`: These customizations apply when we're using Codespaces. `"openFiles": ["README.md"]` means that the `README.md` file that you saw on the main page will automatically pop up when you start the Codespace. It's like walking into a room and finding a welcome note on the table.
 
-- `"vscode": {"extensions": ["ms-toolsai.jupyter", "ms-python.python"]}`: This part tells Visual Studio Code to automatically add two helpers, called extensions, when the Codespace is created:
+- `"vscode": {"extensions": ["ms-toolsai.jupyter", "ms-python.python", "github.copilot"]}`: This part tells Visual Studio Code to automatically add three helpers, called extensions, when the Codespace is created:
 
   - `ms-toolsai.jupyter`: This is like a digital notebook where you can write and run code, and also add notes, images, or even equations. It's very popular in data science because you can see your data and your code side by side. The Jupyter extension lets you use these notebooks right inside Visual Studio Code.
 
-  - `ms-python.python`: This is a helper for writing Python code. It adds features like code suggestions, checks your code for mistakes, and even formats your code to make it look neat and consistent. It's like having a helpful robot that watches over your shoulder while you code.
+  - `ms-python.python`: This is a helper for writing Python code. It adds features like code suggestions, checks your code for mistakes, and even formats your code to make it look neat and consistent. 
+
+  - `github.copilot`: This is an AI-powered extension that assists you in writing code. It suggests code as you type based on patterns in publicly available code. It's like having a co-pilot that helps you navigate and improve your code. After activating it with the code provided by us, you can chat with it by using the speech bubble icon on the left side.
+
 
 By including these extensions in our `devcontainer.json` file, we make sure they are automatically added in the Codespace. This means you don't have to add them yourself, and everyone working on the project has the same setup.
 


### PR DESCRIPTION
This pull request includes changes to the `.devcontainer/devcontainer.json` file to set up a development environment in a container. The changes specify the use of a universal image from Microsoft's container registry, define a post-creation command to install Python requirements, and add customizations for Codespaces and VS Code. 

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R15): The file has been created to define the development container. It uses the `mcr.microsoft.com/devcontainers/universal:2` image and runs `python3 -m pip install -r Application/requirements.txt` after the container is created. It also specifies that `README.md` should be opened in Codespaces and that the Jupyter and Python extensions should be installed in VS Code.