### PR TITLE
Correction Needed: Image Description Mismatch for Android Homescreen

### DIFF
--- a/instructions/day1/ApplicationPart2/README.md
+++ b/instructions/day1/ApplicationPart2/README.md
@@ -119,7 +119,7 @@ appstore. Therefore, we will not add the app to our phones' homescreen.
   - This is how it should look like on ios:
     ![Add to homescreen ios](./images/FrontendHomescreen1.jpg)
   - This is how it should look on Android:
-    ![Add to homescreen Android](./images/FrontendHomescreen1.jpg)
+    ![Add to homescreen Android](./images/FrontendHomescreenAndroid.jpg)
 - Now you can open the website like a normal app from the homescreen of your phone.
 
 ## Milligram application backend


### PR DESCRIPTION
Beneath the following sentence, there is an image of the iOS homescreen.
> This is how it should look on Android:

I have corrected it to point to the Android homescreen image.